### PR TITLE
mapProps: differentiate from TChildProps and TPassedInProps

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -19,9 +19,9 @@ declare module 'recompose' {
         getChildContext: (props: ComponentOwnProps) => any
     ): InferableComponentDecorator;
 
-    export function mapProps<TOriginalProps, TOwnProps>(
-        propsMapper: (props: TOriginalProps) => TOwnProps
-    ): ComponentDecorator<TOriginalProps, TOwnProps>;
+    export function mapProps<TOwnProps, TMappedProps, TChildProps>(
+        propsMapper: (props: TOwnProps) => TMappedProps
+    ): ComponentDecorator<TChildProps, TOwnProps>;
 
     export function withProps<TOriginalProps, TOwnProps>(
         createProps: (props: TOriginalProps) => TOriginalProps & TOwnProps | TOwnProps


### PR DESCRIPTION
I was having some issues with mapProps. I think we need to differentiate between the props passed to the HOC and the props for the child. This way, you can properly capture the prop types that are passed into the component, and allow them to be different that the props of the child component.

I could not get the test suite running... so any help with that would be awesome! Let me know what you think :smile: 
